### PR TITLE
Bugfix/ruby composite field order bug

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,9 @@ require 'fileutils'
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 
-RSpec::Core::RakeTask.new(:spec)
+RSpec::Core::RakeTask.new(:spec) do |t|
+  t.pattern = "*/**/*_spec.rb"
+end
 
 task :default => :spec
 task :default => :greatest

--- a/support/ruby/spec/cauterize_ruby_builtins_spec.rb
+++ b/support/ruby/spec/cauterize_ruby_builtins_spec.rb
@@ -1,0 +1,247 @@
+require 'tmpdir'
+require 'fileutils'
+
+require_relative '../src/cauterize_ruby_builtins'
+
+module Cauterize
+
+  describe "Cauterize's Ruby built-ins" do
+    def get_byte(str,idx)
+      str.bytes.to_a[idx]
+    end
+
+    def expect_out_of_range(&block)
+      block.should raise_error(/Out of range value/)
+    end
+
+    describe "Bool" do
+      it "can be instantiated, packed and unpacked" do
+        x = Bool.new(true)
+        x.to_ruby.should == true
+
+        s = x.pack
+        get_byte(s,0).should == 1
+
+        y = Bool.unpack(s) 
+        y.to_ruby.should == true
+
+        # False:
+        x = Bool.new(false)
+        x.to_ruby.should == false
+
+        s = x.pack
+        get_byte(s,0).should == 0
+
+        y = Bool.unpack(s) 
+        y.to_ruby.should == false
+      end
+    end
+
+    describe "UInt8" do
+      it "can be instantiated, packed and unpacked" do
+        x = UInt8.new(42)
+        x.to_ruby.should == 42
+
+        s = x.pack
+        get_byte(s,0).should == 42
+
+        y = UInt8.unpack(s) 
+        y.to_ruby.should == 42
+      end
+
+      it "rejects out-of-range values" do
+        expect_out_of_range do UInt8.new(-1) end
+        expect_out_of_range { UInt8.new(256) }
+      end
+    end
+
+    describe "UInt16" do
+      it "can be instantiated, packed and unpacked" do
+        x = UInt16.new(0xABCD)
+        x.to_ruby.should == 0xABCD
+
+        s = x.pack
+        get_byte(s,0).should == 0xCD # little endien
+        get_byte(s,1).should == 0xAB
+
+        y = UInt16.unpack(s) 
+        y.to_ruby.should == 0xABCD
+      end
+
+      it "rejects out-of-range values" do
+        expect_out_of_range do UInt16.new(-1) end
+        expect_out_of_range { UInt16.new(0x10000) }
+      end
+    end
+
+    describe "UInt32" do
+      it "can be instantiated, packed and unpacked" do
+        num = 0xDEADBEEF
+        x = UInt32.new(num)
+        x.to_ruby.should == num
+
+        s = x.pack
+        get_byte(s,0).should == 0xEF # little endien
+        get_byte(s,1).should == 0xBE
+        get_byte(s,2).should == 0xAD
+        get_byte(s,3).should == 0xDE
+
+        y = UInt32.unpack(s) 
+        y.to_ruby.should == num
+      end
+
+      it "rejects out-of-range values" do
+        expect_out_of_range do UInt32.new(-1) end
+        expect_out_of_range { UInt32.new(2**32) }
+      end
+    end
+
+    describe "UInt64" do
+      it "can be instantiated, packed and unpacked" do
+        num = 0xCAFEBABEDEADBEEF
+        x = UInt64.new(num)
+        x.to_ruby.should == num
+
+        s = x.pack
+        get_byte(s,0).should == 0xEF # little endien
+        get_byte(s,1).should == 0xBE
+        get_byte(s,2).should == 0xAD
+        get_byte(s,3).should == 0xDE
+        get_byte(s,4).should == 0xBE 
+        get_byte(s,5).should == 0xBA
+        get_byte(s,6).should == 0xFE
+        get_byte(s,7).should == 0xCA
+
+        y = UInt64.unpack(s) 
+        y.to_ruby.should == num
+      end
+
+      it "rejects out-of-range values" do
+        expect_out_of_range do UInt64.new(-1) end
+        expect_out_of_range { UInt64.new(2**64) }
+      end
+    end
+
+    describe "Int8" do
+      it "can be instantiated, packed and unpacked" do
+        x = Int8.new(42)
+        x.to_ruby.should == 42
+
+        s = x.pack
+        get_byte(s,0).should == 42
+
+        y = Int8.unpack(s) 
+        y.to_ruby.should == 42
+      end
+
+      it "handles negative vals" do
+        x = Int8.new(-42)
+        x.to_ruby.should == -42
+        s = x.pack
+        get_byte(s,0).should == 0xD6
+      end
+
+      it "rejects out-of-range values" do
+        expect_out_of_range do Int8.new(-129) end
+        expect_out_of_range { Int8.new(128) }
+      end
+    end
+
+    describe "Int16" do
+      it "can be instantiated, packed and unpacked" do
+        x = Int16.new(0xBCD)
+        x.to_ruby.should == 0xBCD
+
+        s = x.pack
+        get_byte(s,0).should == 0xCD # little endien
+        get_byte(s,1).should == 0x0B
+
+        y = Int16.unpack(s) 
+        y.to_ruby.should == 0xBCD
+      end
+
+      it "handles negative vals" do
+        x = Int16.new(-42)
+        x.to_ruby.should == -42
+        s = x.pack
+        get_byte(s,0).should == 0xD6
+      end
+
+      it "rejects out-of-range values" do
+        expect_out_of_range do Int16.new(-32769) end
+        expect_out_of_range { Int16.new(32768) }
+      end
+    end
+
+    describe "Int32" do
+      it "can be instantiated, packed and unpacked" do
+        num = 0xDEADBEE
+        x = Int32.new(num)
+        x.to_ruby.should == num
+
+        s = x.pack
+        get_byte(s,0).should == 0xEE # little endien
+        get_byte(s,1).should == 0xDB
+        get_byte(s,2).should == 0xEA
+        get_byte(s,3).should == 0x0D
+
+        y = Int32.unpack(s) 
+        y.to_ruby.should == num
+      end
+
+      it "handles negative vals" do
+        x = Int32.new(-42)
+        x.to_ruby.should == -42
+        s = x.pack
+        get_byte(s,0).should == 0xD6
+      end
+
+      it "rejects out-of-range values" do
+        edge = 2**31
+        Int32.new(-edge) # lower edge of ok
+        Int32.new(edge-1) # upper edge of ok
+        expect_out_of_range do Int32.new(-(edge+1)) end
+        expect_out_of_range { Int32.new(edge) }
+      end
+    end
+
+    describe "Float32" do
+      it "can be instantiated, packed and unpacked" do
+        [ -123.456, 3001.4001, 42.424242 ].each do |num|
+          obj = Float32.new(num)
+          obj.to_ruby.should == num
+          str = obj.pack
+          str.length.should == 4
+          Float32.unpack(str).to_ruby.should be_within(0.0001).of(num)
+        end
+      end
+
+      it "rejects out-of-range values" do
+        lower_not_ok = -3.402823466e38
+        upper_not_ok = 3.402823466e38
+        expect_out_of_range { Float32.new(lower_not_ok) }
+        expect_out_of_range { Float32.new(upper_not_ok) }
+      end
+    end
+
+    describe "Float64" do
+      it "can be instantiated, packed and unpacked" do
+        [ -123.456, 3001.4001, 42.424242 ].each do |num|
+          obj = Float64.new(num)
+          obj.to_ruby.should == num
+          str = obj.pack
+          str.length.should == 8
+          Float64.unpack(str).to_ruby.should be_within(0.0001).of(num)
+        end
+      end
+
+      it "handles more extreme values than Float32" do
+        small_ok = -3.402823466e38
+        big_ok = 3.402823466e38
+        Float64.new(small_ok) # should be ok
+        Float64.new(big_ok) # should be ok
+      end
+    end
+
+  end # describe Built-ins
+end # Cauterize module

--- a/support/ruby/spec/user_defined_types_spec.rb
+++ b/support/ruby/spec/user_defined_types_spec.rb
@@ -1,6 +1,5 @@
 require 'tmpdir'
 require 'fileutils'
-require 'pry'
 
 require_relative '../src/cauterize_ruby_builtins'
 
@@ -151,67 +150,6 @@ module Cauterize
         end
         
       EOF
-=begin
-variable_array(:uint8_buffer) do |a|
-  a.size_type  :uint8
-  a.array_type :uint8
-  a.array_size 128
-end
-
-
-enumeration(:large_value) do |e|
-  e.value :negative, -500
-  e.value :positive, 500
-end
-
-fixed_array(:color_list) do |a|
-  a.array_type :color
-  a.array_size 41
-end
-
-composite(:weirdness) do |c|
-  c.field :val, :large_value
-  c.field :num, :int8
-end
- 
-fixed_array(:color_list_list) do |a|
-  a.array_type :color_list
-  a.array_size 4
-end
- 
-variable_array(:numbers) do |a|
-  a.size_type  :usmallint
-  a.array_type :bigint
-  a.array_size 128
-end
-
-composite(:nonsensical) do |c|
-  c.field :color, :color
-  c.field :color_list, :color_list
-  c.field :numbers, :numbers
-  c.field :a_float, :float64
-  c.field :a_bool, :bool
-end
-
-composite(:crazy) do |c|
-  c.field :first_numbers, :numbers
-  c.field :second_numbers, :numbers
-  c.field :third_numbers, :numbers
-end
-
-group(:insanity) do |g|
-  g.field :nonsensical, :nonsensical
-  g.field :crazy, :crazy
-  g.dataless :any_empty_entry
-  g.dataless :another_empty
-end
-
-group(:wat) do |g|
-  g.field :arrrr, :color_list_list
-  g.field :coooo, :color
-  g.dataless :ohnoes
-end
-=end
     end
   end # describe user types
 end # Cauterize module

--- a/support/ruby/spec/user_defined_types_spec.rb
+++ b/support/ruby/spec/user_defined_types_spec.rb
@@ -1,0 +1,217 @@
+require 'tmpdir'
+require 'fileutils'
+require 'pry'
+
+require_relative '../src/cauterize_ruby_builtins'
+
+module Cauterize
+
+  describe "various derived user types" do
+
+    let!(:test_proj_dir) { Dir.mktmpdir("test_proj_1") }
+    let(:app_root) { File.expand_path(File.dirname(__FILE__) + "/../../..") }
+    let(:cauterize_tool) { "#{app_root}/bin/cauterize" }
+
+   
+    before do
+      FileUtils.cd test_proj_dir do
+        # Write Cauterize file
+        File.open("Cauterize","w") do |f|
+          f.puts cauterize_file_text
+        end
+        # Run the tool to generate Ruby lib code
+        system %{#{cauterize_tool} generate ruby test1}
+  
+        # Load the lib code
+        $LOAD_PATH << "#{test_proj_dir}/test1"
+        require 'test1'
+      end
+    end
+
+    after do
+      FileUtils.remove_entry_secure test_proj_dir
+    end
+
+    it "works" do
+      
+      #
+      # SCALAR
+      #
+      b = Test1Byte.new(255)
+      Test1Byte.unpack(b.pack).to_ruby.should == 255
+
+      i = Test1Int.new(-200)
+      Test1Int.unpack(i.pack).to_ruby.should == -200
+
+      #
+      # ENUMERATION
+      #
+      c = Test1Color::RED
+      Test1Color.unpack(c.pack).to_ruby.should == :RED
+
+      c2 = Test1Color::GREEN
+      Test1Color.unpack(c2.pack).to_ruby.should == :GREEN
+
+      #
+      # COMPOSITE
+      #
+      #   Regression test: :test1_dot declares that the :color field 
+      #   comes before the x and y values.  Since this is a Ruby Hash literal,
+      #   we should be allowed to specify the keys in any order we like as long 
+      #   as all are present.
+      #
+      loc = Test1Dot.new(
+        x: 100,
+        y: 200,
+        color: :BLUE  # defined as first, should be ok to specify it last.
+      )
+      loc.color.class.should == Test1Color
+      loc.color.to_ruby.should == :BLUE
+      loc.x.to_ruby.should == 100
+      loc.y.to_ruby.should == 200
+
+      loc.pack.should == loc.color.pack + loc.x.pack + loc.y.pack
+
+      loc2 = Test1Dot.unpack(loc.pack)
+      loc2.color.class.should == Test1Color
+      loc2.color.to_ruby.should == :BLUE
+      loc2.x.to_ruby.should == 100
+      loc2.y.to_ruby.should == 200
+
+      #
+      # FIXED ARRAY
+      #
+      tri = Test1Tri.new([{x:10,y:20,color: :RED},
+                         {x:30,y:40,color: :GREEN},
+                         {x:50,y:60,color: :BLUE}])
+      tri2 = Test1Tri.unpack(tri.pack)
+      tri2.to_ruby.should == tri.to_ruby
+
+      #
+      # VARIABLE ARRAY
+      #
+      str = Test1ByteString.new( "hello".bytes.to_a )
+      get_byte(str.pack, 0).should == 5 # length field sneaks in at the front of the list
+      str2 = Test1ByteString.unpack(str.pack)
+      str2.to_ruby.should == [104, 101, 108, 108, 111]
+
+      # See we can't put an 11-length string in there:
+      lambda do Test1ByteString.new( "0123456789_".bytes.to_a ) end.should raise_error(/invalid length/i)
+
+      #
+      # GROUP
+      #
+
+    end
+
+    # TODO test:
+    # Group
+
+    #
+    # HELPERS
+    # 
+
+    def get_byte(str,idx)
+      str.bytes.to_a[idx]
+    end
+
+    def expect_out_of_range(&block)
+      block.should raise_error(/Out of range value/)
+    end
+
+    def cauterize_file_text 
+      @cauterize_file_text ||=<<-EOF
+        set_name("test1")
+        set_version("1.2.3")
+
+        scalar(:test1_int)  { |t| t.type_name(:int32) }
+        scalar(:test1_byte) { |t| t.type_name(:uint8) }
+
+        enumeration(:test1_color) do |e|
+          e.value :red
+          e.value :blue
+          e.value :green
+        end
+
+        composite(:test1_dot) do |c|
+          c.field :color, :test1_color
+          c.field :x, :test1_int
+          c.field :y, :test1_int
+        end
+
+        fixed_array(:test1_tri) do |a|
+          a.array_type :test1_dot
+          a.array_size 3
+        end
+
+        variable_array(:test1_byte_string) do |a|
+          a.array_type :test1_byte
+          a.size_type :uint8
+          a.array_size 10 
+        end
+        
+      EOF
+=begin
+variable_array(:uint8_buffer) do |a|
+  a.size_type  :uint8
+  a.array_type :uint8
+  a.array_size 128
+end
+
+
+enumeration(:large_value) do |e|
+  e.value :negative, -500
+  e.value :positive, 500
+end
+
+fixed_array(:color_list) do |a|
+  a.array_type :color
+  a.array_size 41
+end
+
+composite(:weirdness) do |c|
+  c.field :val, :large_value
+  c.field :num, :int8
+end
+ 
+fixed_array(:color_list_list) do |a|
+  a.array_type :color_list
+  a.array_size 4
+end
+ 
+variable_array(:numbers) do |a|
+  a.size_type  :usmallint
+  a.array_type :bigint
+  a.array_size 128
+end
+
+composite(:nonsensical) do |c|
+  c.field :color, :color
+  c.field :color_list, :color_list
+  c.field :numbers, :numbers
+  c.field :a_float, :float64
+  c.field :a_bool, :bool
+end
+
+composite(:crazy) do |c|
+  c.field :first_numbers, :numbers
+  c.field :second_numbers, :numbers
+  c.field :third_numbers, :numbers
+end
+
+group(:insanity) do |g|
+  g.field :nonsensical, :nonsensical
+  g.field :crazy, :crazy
+  g.dataless :any_empty_entry
+  g.dataless :another_empty
+end
+
+group(:wat) do |g|
+  g.field :arrrr, :color_list_list
+  g.field :coooo, :color
+  g.dataless :ohnoes
+end
+=end
+    end
+  end # describe user types
+end # Cauterize module

--- a/support/ruby/src/cauterize_ruby_baseclasses.rb
+++ b/support/ruby/src/cauterize_ruby_baseclasses.rb
@@ -123,12 +123,13 @@ class CauterizeComposite < CauterizeData
   attr_reader :fields
 
   def initialize(field_values)
-    missing_keys = self.class.fields.keys - field_values.keys
-    extra_keys = field_values.keys - self.class.fields.keys
+    field_defs = self.class.fields
+    missing_keys = field_defs.keys - field_values.keys
+    extra_keys = field_values.keys - field_defs.keys
     raise "missing fields #{missing_keys}" if not missing_keys.empty?
     raise "extra fields #{extra_keys}" if not extra_keys.empty?
-    @fields = Hash[field_values.map do |field_name, value|
-      [field_name, self.class.fields[field_name].construct(value)]
+    @fields = Hash[field_defs.map do |field_name, field_def|
+      [field_name, field_def.construct(field_values[field_name])]
     end]
   end
 


### PR DESCRIPTION
This branch contains:
- fix to support/ruby/src/cauterize_ruby_baseclasses.rb that makes Composite's constructor insensitive to the ordering of hash keys you supply to construct new instances.
- the beginnings of a test suite for the Ruby support code.

"rake spec" task has been broadened to include all specs in the repo, not just those under "spec/" because  I stashed the Ruby support specs under the support directory.
